### PR TITLE
Increase font sizes for title and subtitle

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -148,14 +148,14 @@ header .container .button:hover .circle {
 }
 
 .main .container .text .title {
-    font-size: 2rem;
+    font-size: 3rem;
     color: #ffffff;
     display: flex;
 }
 
 .main .container .text .subtitle {
   white-space: nowrap;
-  font-size: 3rem;
+  font-size: 5rem;
   font-weight: 600;
   color: #ffffff;
 }


### PR DESCRIPTION
Updated .main .container .text .title font size from 2rem to 3rem and .subtitle from 3rem to 5rem to improve text visibility and emphasis.