### PR TITLE
Increase hover circle size in header buttons

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -125,8 +125,8 @@ header .container .button:active {
 }
 
 header .container .button:hover .circle {
-  width: 220px;
-  height: 220px;
+  width: 300px;
+  height: 300px;
   opacity: 1;
 }
 

--- a/static/user.css
+++ b/static/user.css
@@ -54,8 +54,8 @@ header .back-btn .text {
 }
 
 header .back-btn:hover .circle {
-  width: 220px;
-  height: 220px;
+  width: 300px;
+  height: 300px;
   opacity: 1;
 }
 


### PR DESCRIPTION
Updated the width and height of the .circle element on hover from 220px to 300px in both style.css and user.css to enhance the visual effect for header buttons.